### PR TITLE
feat: implement Next.js data cache for frontend API calls

### DIFF
--- a/frontend/src/features/actress-detail/api.ts
+++ b/frontend/src/features/actress-detail/api.ts
@@ -23,11 +23,13 @@ export async function getActressDetail(personId: number): Promise<ActressDetail>
   try {
     logger.info("女優詳細情報を取得中", { personId });
 
-    const response = await fetch(`http://backend:10000/api/persons/${personId}`, {
+    const API_BASE_URL = process.env.API_BASE_URL || "http://backend:10000";
+    const response = await fetch(`${API_BASE_URL}/api/persons/${personId}`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
       },
+      next: { revalidate: 86400 }, // 1日（24時間）キャッシュ
     });
 
     if (!response.ok) {

--- a/frontend/src/features/ranking/api.ts
+++ b/frontend/src/features/ranking/api.ts
@@ -11,7 +11,7 @@ export async function getRankingData(): Promise<RankingResponse | null> {
     // 環境変数からAPI URLを取得（デプロイ環境とローカル環境で異なる）
     const API_BASE_URL = process.env.API_BASE_URL || "http://backend:10000";
     const response = await fetch(`${API_BASE_URL}/api/ranking?limit=5`, {
-      cache: "no-store", // リアルタイムなランキング情報を取得
+      next: { revalidate: 3600 }, // 1時間キャッシュ
     });
 
     if (!response.ok) {

--- a/frontend/src/features/search-results/api.ts
+++ b/frontend/src/features/search-results/api.ts
@@ -16,7 +16,7 @@ export async function getSearchSessionResults(
 
     const API_BASE_URL = process.env.API_BASE_URL || "http://backend:10000";
     const response = await fetch(`${API_BASE_URL}/api/search/${sessionId}`, {
-      cache: "no-store",
+      next: { revalidate: 86400 }, // 1日（24時間）キャッシュ
     });
 
     if (!response.ok) {

--- a/frontend/src/lib/age-verification.test.ts
+++ b/frontend/src/lib/age-verification.test.ts
@@ -100,7 +100,9 @@ describe("age-verification", () => {
     });
 
     it("エラーが発生した場合は例外を投げる", async () => {
-      (cookies as vi.MockedFunction<typeof cookies>).mockRejectedValue(new Error("Cookie set error"));
+      (cookies as vi.MockedFunction<typeof cookies>).mockRejectedValue(
+        new Error("Cookie set error"),
+      );
 
       await expect(setAgeVerified()).rejects.toThrow("年齢認証の設定に失敗しました");
     });
@@ -114,7 +116,9 @@ describe("age-verification", () => {
     });
 
     it("エラーが発生した場合は例外を投げる", async () => {
-      (cookies as vi.MockedFunction<typeof cookies>).mockRejectedValue(new Error("Cookie delete error"));
+      (cookies as vi.MockedFunction<typeof cookies>).mockRejectedValue(
+        new Error("Cookie delete error"),
+      );
 
       await expect(clearAgeVerification()).rejects.toThrow("年齢認証のクリアに失敗しました");
     });


### PR DESCRIPTION
## Summary
- Implement Next.js App Router data cache for API endpoints to reduce backend load
- Add appropriate cache durations based on data characteristics and update frequency
- Improve application performance while maintaining data freshness

## Changes
- **Actress Detail API**: 24-hour cache (actress information is relatively static)
- **Search Results API**: 24-hour cache (session results are immutable once generated)
- **Ranking API**: 1-hour cache (balance between freshness and performance)

## Technical Details
- Use Next.js `fetch` API with `next: { revalidate }` option
- Replace `cache: "no-store"` with appropriate revalidation times
- Maintain existing API URL configuration and error handling

## Test Plan
- [x] Verify all existing tests continue to pass
- [x] Confirm cache settings are correctly applied
- [x] Run lint checks and ensure code quality
- [x] Test API endpoints work correctly with caching

🤖 Generated with [Claude Code](https://claude.ai/code)